### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,17 @@ php:
   - 7.2
   - nightly
 
+matrix:
+  allow_failures:
+    -php: nightly
+
 install:
   - if [[ "$TRAVIS_PHP_VERSION" != "nightly" ]]; then phpenv config-rm xdebug.ini; fi
-  - travis_retry composer self-update
-  - travis_retry composer install --prefer-dist --dev
+  - travis_retry composer install --prefer-dist -n
 
 script:
   - mkdir -p build/logs
-  - phpdbg -qrr vendor/bin/phpunit -c phpunit.xml.dist
+  - phpdbg -qrr vendor/bin/phpunit
 
 after_script:
   - travis_retry vendor/bin/php-coveralls -v

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,17 @@
         "php": ">=7.1.0",
         "kornrunner/keccak": "^1.0",
         "simplito/bn-php": "^1.0",
-        "ext-gmp": "^7.1"
+        "ext-gmp": "^7.1",
+        "ext-mbstring": "*"
     },
     "autoload": {
         "psr-4": {
             "kornrunner\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "kornrunner\\": "test"
         }
     },
     "require-dev": {

--- a/test/SolidityTest.php
+++ b/test/SolidityTest.php
@@ -1,9 +1,11 @@
 <?php
 
-use BN\BN;
-use kornrunner\Solidity;
+namespace kornrunner;
 
-class SolidityTest extends PHPUnit\Framework\TestCase
+use BN\BN;
+use PHPUnit\Framework\TestCase;
+
+class SolidityTest extends TestCase
 {
     private const contractAddress = '0x2a0c0dbecc7e4d658f48e01e3fa353f44050c208';
     private const tokenBuy = '0x0000000000000000000000000000000000000000';


### PR DESCRIPTION
# Changed log

- Set the ```php-nightly``` in allow_failures setting when executing the Travis build.
- Check the ```ext-mbstring``` when executing the Composer command.
- The ```composer self-update``` is executed by default in Travis build.
- The ```--dev``` option in composer command is deprecated.
- Use the ```composer update --prefer-dist -n``` to update the dependencies for the different PHP versions tests because the ```composer.lock``` will cache the dependencies version when executing the ```composer install```.
