### PR TITLE
Add sha256() or make hex() public

### DIFF
--- a/src/Solidity.php
+++ b/src/Solidity.php
@@ -53,4 +53,10 @@ final class Solidity {
         $hex_glued = strtolower(implode('', $hex_array));
         return '0x' . Keccak::hash(hex2bin($hex_glued), self::HASH_SIZE);
     }
+    
+    public static function sha256(...$args): string {
+        $hex_array = array_map(__CLASS__ . '::hex', $args);
+        $hex_glued = strtolower(implode('', $hex_array));
+        return '0x' . hash('sha256', $hex_glued);
+    }
 }

--- a/src/Solidity.php
+++ b/src/Solidity.php
@@ -6,7 +6,7 @@ use BN\BN;
 final class Solidity {
     private const HASH_SIZE = 256;
 
-    private static function hex ($input): string {
+    public static function hex ($input): string {
         if ($input instanceof BN) {
             $input = $input->toString();
         } elseif (is_bool($input)) {
@@ -52,11 +52,5 @@ final class Solidity {
         $hex_array = array_map(__CLASS__ . '::hex', $args);
         $hex_glued = strtolower(implode('', $hex_array));
         return '0x' . Keccak::hash(hex2bin($hex_glued), self::HASH_SIZE);
-    }
-    
-    public static function sha256(...$args): string {
-        $hex_array = array_map(__CLASS__ . '::hex', $args);
-        $hex_glued = strtolower(implode('', $hex_array));
-        return '0x' . hash('sha256', $hex_glued);
     }
 }


### PR DESCRIPTION
The `SHA256` hash is needed sometimes, however, because the `Solidity::hex()` method is private, the user doesn't have any means of reusing this great code with other hash types. 

Thus I would propose either of the following:

- make `hex()` public or
- add `sha256()` public method

Up to you whether you want to merge it or not, but if you do, that would be great. Any of the above two ways works for me. Making `hex()` public is probably a lot less intrusive, basically a one-liner edit.

```PHP
    public static function sha256(...$args): string {
        $hex_array = array_map(__CLASS__ . '::hex', $args);
        $hex_glued = strtolower(implode('', $hex_array));
        return '0x' . hash('sha256', $hex_glued);
    }
```

Thx!